### PR TITLE
Allowing NULL disc.method in the case variables are already discrete

### DIFF
--- a/R/prepareTransactions.R
+++ b/R/prepareTransactions.R
@@ -49,23 +49,33 @@ prepareTransactions <- function(formula, data, disc.method = "mdlp", match = NUL
       if(is.logical(data[[i]]))
         data[[i]] <- factor(data[[i]], levels = c(TRUE, FALSE))
   }
+
   # disc.method is a character string with the method
-  if(!is.list(disc.method)) {
+  if(!is.null(disc.method)) {
+    if(!is.list(disc.method)) {
+      disc_info <- NULL
+      data <- discretizeDF.supervised(formula, data, method = disc.method)
+      disc_info <- lapply(data, attr, "discretized:breaks")
+      
+      data <- as(data, "transactions")
+      attr(data, "disc_info") <- disc_info
 
-    disc_info <- NULL
-    data <- discretizeDF.supervised(formula, data, method = disc.method)
-    disc_info <- lapply(data, attr, "discretized:breaks")
+      return(data)
+    }
+
+    ### disc is a list with discretization info
+    data <- discretizeDF(
+      df = data,
+      methods = lapply(
+        X = disc.method,
+        FUN = function(x) list(method = "fixed", breaks = x)
+      )
+    )
 
     data <- as(data, "transactions")
-    attr(data, "disc_info") <- disc_info
-
-    return(data)
+  } else {
+    data <- as(data, "transactions")
   }
-
-  ### disc is a list with discretization info
-    data <- discretizeDF(data, lapply(disc.method,
-      FUN = function(x) list(method = "fixed", breaks = x)))
-    data <- as(data, "transactions")
 
   return(data)
 }

--- a/tests/testthat/test-discretize.R
+++ b/tests/testthat/test-discretize.R
@@ -1,7 +1,6 @@
 library("testthat")
 library("arulesCBA")
 
-
 context("Discretization")
 
 data("iris")
@@ -20,4 +19,10 @@ iris[1:5,1] <- NA
 disc <- discretizeDF.supervised(Species ~ ., iris)
 disc <- discretizeDF.supervised(Species ~ ., iris, method = "chi2")
 
+iris$disc1 <- cut(iris$Sepal.Length, breaks = 2, include.lowest = TRUE, right = TRUE)
+iris$disc2 <- cut(iris$Petal.Length, breaks = 2, include.lowest = TRUE, right = TRUE)
 
+# no disc.method
+expect_error(discretizeDF.supervised(Species ~ disc1 + disc2, iris, method = "chi2"))
+iris_cat <- iris[c("Species", "disc1", "disc2")]
+expect_no_error(prepareTransactions(Species ~ disc1 + disc2, data = iris_cat, disc.method = NULL))


### PR DESCRIPTION
# Link to the issue

close #29

# How to test the changes

```
data(iris)

iris$disc1 <- cut(iris$Sepal.Length, breaks = 2, include.lowest = TRUE, right = TRUE)
iris$disc2 <- cut(iris$Petal.Length, breaks = 2, include.lowest = TRUE, right = TRUE)

iris_cat <- iris[c("Species", "disc1", "disc2")]

# no disc.method
prepareTransactions(formula = Species ~ disc1 + disc2, data = iris_cat, disc.method = NULL)
```