### PR TITLE
Adding the possibility to skip pruning step when using CBA function

### DIFF
--- a/R/CBA.R
+++ b/R/CBA.R
@@ -17,7 +17,7 @@
 #' of form \code{class ~ .} or \code{class ~ predictor1 + predictor2}.
 #' @param data A data.frame or a transaction set containing the training data.
 #' Data frames are automatically discretized and converted to transactions.
-#' @param pruning Pruning strategy used: "M1" or "M2".
+#' @param pruning Pruning strategy used: "M1" or "M2". NULL to skip pruning step.
 #' @param parameter,control Optional parameter and control lists for apriori.
 #' @param balanceSupport balanceSupport parameter passed to
 #' \code{\link{mineCARs}} function.
@@ -79,8 +79,10 @@ CBA <- function(formula, data, pruning = "M1",
     verbose = verbose, ...)
 
   if(verbose) cat("\nPruning CARs...\n")
-  if(pruning == "M1") rulebase <- pruneCBA_M1(formula, rulebase, trans)
-  else rulebase <- pruneCBA_M2(formula, rulebase, trans)
+  if(!is.null(pruning)) {
+    if(pruning == "M1") rulebase <- pruneCBA_M1(formula, rulebase, trans)
+    else rulebase <- pruneCBA_M2(formula, rulebase, trans)
+  }
 
   if(verbose) cat("CARs left:", length(rulebase), "\n")
 

--- a/man/CBA.Rd
+++ b/man/CBA.Rd
@@ -30,7 +30,7 @@ of form \code{class ~ .} or \code{class ~ predictor1 + predictor2}.}
 \item{data}{A data.frame or a transaction set containing the training data.
 Data frames are automatically discretized and converted to transactions.}
 
-\item{pruning}{Pruning strategy used: "M1" or "M2".}
+\item{pruning}{Pruning strategy used: "M1" or "M2". NULL to skip pruning step.}
 
 \item{parameter, control}{Optional parameter and control lists for apriori.}
 

--- a/tests/testthat/test-CBA.R
+++ b/tests/testthat/test-CBA.R
@@ -1,15 +1,30 @@
 library("testthat")
 library("arulesCBA")
-data("iris")
 
 context("CBA")
 
-cba_classifier <- CBA(Species ~ ., iris, supp = 0.05, conf = 0.9, pruning = "M1")
+data("iris")
+formula <- Species ~ .
+
+trans <- prepareTransactions(formula, iris, disc.method = "mdlp")
+rulebase <- mineCARs(
+  formula = Species ~ .,
+  transactions = trans,
+  supp = 0.05,
+  conf = 0.9
+)
+n_rules <- length(rulebase)
+
+cba_no_pruning <- CBA(formula, iris, supp = 0.05, conf = 0.9, pruning = NULL)
+expect_equal(length(rules(cba_no_pruning)), n_rules)
+
+cba_classifier <- CBA(formula, iris, supp = 0.05, conf = 0.9, pruning = "M1")
 expect_equal(length(rules(cba_classifier)), 8L)
 
 results <- predict(cba_classifier, iris)
-expect_equal(results[1], factor("setosa",
-  levels = c("setosa", "versicolor", "virginica")))
+expect_equal(
+  results[1], factor("setosa", levels = c("setosa", "versicolor", "virginica"))
+)
 
 results <- predict(cba_classifier, head(iris, n = 5))
 expect_equal(length(results), 5L)
@@ -25,7 +40,7 @@ results <- predict(cba_classifier, head(iris, n = 5))
 expect_equal(length(results), 5L)
 
 # FIXME: We need to check what the output of M2 should be
-cba_classifier_M2 <- CBA(Species ~ ., iris, supp = 0.05, conf = 0.9, pruning = "M2")
+cba_classifier_M2 <- CBA(formula, iris, supp = 0.05, conf = 0.9, pruning = "M2")
 # FIXME: there is a bug in totalError calculation in M2
 #expect_equal(length(rules(cba_classifier_M2)), 8L)
 


### PR DESCRIPTION
# Link to the issue

close #30 

# How to test the changes

```
data("iris")
formula <- Species ~ .

trans <- prepareTransactions(formula = formula, data = iris)
rulebase <- mineCARs(
  formula = Species ~ .,
  transactions = trans,
  supp = 0.05,
  conf = 0.9
)
n_rules <- length(rulebase)

cba_no_pruning <- CBA(formula, iris, supp = 0.05, conf = 0.9, pruning = NULL)
```

In this case, `length(rules(cba_no_pruning)) == n_rules` as desired.